### PR TITLE
Inline template

### DIFF
--- a/src/onlyoffice-editor.js
+++ b/src/onlyoffice-editor.js
@@ -19,7 +19,7 @@ angular.module('onlyoffice').directive('onlyofficeEditor', [function () {
   };
 
   return {
-    templateUrl: '/vendor/onlyoffice-angular/src/onlyoffice-editor.tpl.html',
+    template: '<div id="onlyoffice-editor"></div>',
     scope: {
       save: '&'
     },

--- a/src/onlyoffice-editor.tpl.html
+++ b/src/onlyoffice-editor.tpl.html
@@ -1,1 +1,0 @@
-<div id="onlyoffice-editor"></div>


### PR DESCRIPTION
Currently the template is being loaded from a path, which is just another dependecy to include. For small apps its not a problem, but when working with build configurations it requires you to also include an html file, which can be a hassle if you only include .js files in your config. Since the template is so small, it should be fine to inline it, would save some time.

@jasny Please merge if you agree.
