### PR TITLE
Better specification of iframe, fixes legalthings/feedback#137

### DIFF
--- a/src/onlyoffice-editor.js
+++ b/src/onlyoffice-editor.js
@@ -76,7 +76,7 @@ angular.module('onlyoffice').directive('onlyofficeEditor', [function () {
     controller: ['$scope', function ($scope) {
       $scope.saveClose = function () {
         $scope.close = true;
-        var window = angular.element('iframe')[0].contentWindow;
+        var window = angular.element('onlyoffice-editor iframe')[0].contentWindow;
         window.postMessage({command: 'save'}, '*');
       };
 


### PR DESCRIPTION
Before this commit, the first iframe in the page was always selected to
emit messages to. This worked earlier but since we use the zopim widget,
another iframe was added to the page.

**Note: A new version of angular-onlyoffice must be released and afterwards rebuild of the frontend is needed to see the changes**
